### PR TITLE
Orekit validation first approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,27 @@
 # poliastro validation
 
-Validation for poliastro.
+This repository holds validation cases against similar poliastro software.
+Several alternatives are available:
 
-Browse the subdirectories for more details.
+1. Vallado: a collection of routines published in the book "Fundamentals of
+   Astrodynamcis and Applications", by David A.Vallado. Software has been
+   coded in different programming languages and can be found in [Celestrack
+   webpage](https://celestrak.com/software/vallado-sw.php).
+
+2. Orekit: this software is open-source and coded in Java. However, it has a
+   Python wrapper, which makes it ideal for validation testing cases since it is
+   very similar to poliastro. Official web page is hosted
+   [here](https://www.orekit.org/).
+
+3. GMAT: it is an open-source NASA software which stands for General Mission
+   Analysis Tool. Its source code is written in C++ and makes use of OpenGL for
+   visualization purposes. Official web page is hosted
+   [here](https://gmat.atlassian.net/wiki/home).
+
+4. AGI-STK: the reference software in the industry which stands for System Tool
+   Kit. Although it is extremely advance and powerful from the point of view of
+   orbital mechanics, its non open-source nature and the fact that only runs in
+   Windows OS, are disadvantages for validation testing purposes. Official web
+   page is hosted [here](https://gmat.atlassian.net/wiki/home).
+
+

--- a/orekit/README.md
+++ b/orekit/README.md
@@ -1,0 +1,76 @@
+# Orekit validation framework
+
+The following directory holds a validation framework against the [Orekit Python
+wrapper](https://gitlab.orekit.org/orekit-labs/python-wrapper).
+
+
+## How to install
+
+Preferred way of installation, due to the nature of Orekit, is through `conda`.
+Thus, an `environment.yml` file is provided, listing all required dependencies
+for this project. Build a new environment and install required packages by
+running:
+
+
+```bash
+conda env create -f environment.yml
+``` 
+
+Finally, activate the environment by running:
+
+```bash
+conda activate poliastro-validation
+```
+
+where `poliastro-validation` is the name of the previously created conda
+environment.
+
+
+## How to run the tests
+
+The `orekit/tests/` directory holds all necessary configuration files and unit
+tests to be read during the validation process. Therefore, simply run:
+
+```bash
+pytest tests/
+```
+
+Previous command will start a `pytest` session who's configuration is hosted in
+`orekit/tests/pytest.ini`.
+
+
+## A detailed installation of Orekit wrapper
+
+Although the [Orekit](https://gitlab.orekit.org/orekit/orekit) original library
+is developed under Java programming language, a Python wrapper is provided to
+easy interface with all the different routines and classes of the package.
+
+There exist two different ways to [install the
+wrapper](https://gitlab.orekit.org/orekit-labs/python-wrapper/-/wikis/installation):
+automatic or manual. 
+
+1. The automatic installation requires from a Anaconda installation, since
+   Orekit packages are built in the conda-forge system. Then, simply run:
+
+   ```bash
+   conda install -c conda-forge orekit
+   ```
+   
+   to install the wrapper and all additional requirements such us openJDK
+   together with necessary path variables.
+
+2. Regarding the manual installation process, a detailed explanation is
+   available within the
+   [INSTALL.txt](https://gitlab.orekit.org/orekit-labs/python-wrapper/blob/master/INSTALL.txt)
+   file in the official Orekit wrapper repository.
+
+
+## About orekit-data.zip
+
+In the official installation guide of the Orekit wrapper, it is stated that
+physical data (such us epehemeris) needs to be [downlaoded from official
+sources](https://www.orekit.org/download.html).
+
+This file is loaded by the `setup_orekit_curdir()`, which by default will look
+for a ZIP file under the name `orekit-data.zip`.
+

--- a/orekit/environment.yml
+++ b/orekit/environment.yml
@@ -1,0 +1,9 @@
+name: poliastro-validation
+channels:
+  - conda-forge
+dependencies:
+  - astropy
+  - numpy
+  - poliastro
+  - orekit
+  - pytest

--- a/orekit/src/orekit_orbit.py
+++ b/orekit/src/orekit_orbit.py
@@ -1,0 +1,161 @@
+""" Simulate Orekit orbit as poliastro one """
+
+import os
+
+import numpy as np
+from astropy import units as u
+from orekit.pyhelpers import setup_orekit_curdir
+from org.hipparchus.geometry.euclidean.threed import Vector3D
+from org.orekit.frames import FramesFactory
+from org.orekit.orbits import KeplerianOrbit, OrbitType, PositionAngle
+from org.orekit.time import AbsoluteDate
+from org.orekit.utils import Constants, PVCoordinates
+from utils import setup_orekit_env
+
+import orekit
+
+# Start orekit virtual machine and load data
+vm = setup_orekit_env()
+
+
+class OrekitOrbit:
+    """ Generate poliastro likely orbit from orekit API """
+
+    def __init__(self, state):
+        """Initializes the OrekitOrbit from a KeplerianOrbit
+
+        Parameters
+        ----------
+        state: KeplerianOrbit
+
+        """
+        self._state = state
+
+    @property
+    def r(self):
+        """ Position vector """
+        return self._state.getPVCoordinates().position.toArray() * u.m
+
+    @property
+    def v(self):
+        """ velocity vector """
+        return self._state.getPVCoordinates().velocity.toArray() * u.m / u.s
+
+    @property
+    def a(self):
+        """ Semi-major axis """
+        return self._state.getA() * u.m
+
+    @property
+    def ecc(self):
+        """ Eccentricity """
+        return self._state.getE() * u.one
+
+    @property
+    def inc(self):
+        """ Inclination """
+        return self._state.getI() * u.rad
+
+    @property
+    def raan(self):
+        """ Argument of periapsis """
+        # Orekit bounds RAAN between [-pi,pi]. If negative, +2pi is required
+        raan = self._state.getRightAscensionOfAscendingNode()
+
+        if -np.pi < raan < 0:
+            return (raan + 2.0 * np.pi) * u.rad
+        else:
+            return raan * u.rad
+
+    @property
+    def argp(self):
+        """ Argument of perigee """
+        return self._state.getPerigeeArgument() * u.rad
+
+    @property
+    def nu(self):
+        """ True anomaly """
+        return self._state.getTrueAnomaly() * u.rad
+
+    @classmethod
+    def from_vectors(
+        cls,
+        attractor,
+        r,
+        v,
+        epoch=AbsoluteDate.J2000_EPOCH,
+        frame=FramesFactory.getGCRF(),
+    ):
+        """ Builds an OrekitOrbit from position and velocity vectors """
+
+        # Get the value of the coordinates for position and velocity vectors
+        rx, ry, rz = [float(r_coord.to(u.m).value) for r_coord in r]
+        vx, vy, vz = [float(v_coord.to(u.m / u.s).value) for v_coord in v]
+
+        # Convert to Orekit three-dimensional vectors and solve PV instance
+        r_vec, v_vec = Vector3D(rx, ry, rz), Vector3D(vx, vy, vz)
+        rv_state = PVCoordinates(r_vec, v_vec)
+
+        # Get the gravitational parameter
+        k = float(attractor.k.to(u.m ** 3 / u.s ** 2).value)
+
+        # Build a KeplerianOrbit from vectors
+        ss = KeplerianOrbit(rv_state, frame, epoch, k)
+
+        return cls(ss)
+
+    @classmethod
+    def from_classical(
+        cls,
+        attractor,
+        a,
+        ecc,
+        inc,
+        raan,
+        argp,
+        nu,
+        epoch=AbsoluteDate.J2000_EPOCH,
+        frame=FramesFactory.getGCRF(),
+    ):
+
+        # Get rid of units and force float precision
+        k = float(attractor.k.to(u.m ** 3 / u.s ** 2).value)
+        a = float(a.to(u.m).value)
+        ecc = float(ecc.to(u.one).value)
+        inc = float(inc.to(u.rad).value)
+        raan = float(raan.to(u.rad).value)
+        argp = float(argp.to(u.rad).value)
+        nu = float(nu.to(u.rad).value)
+
+        # Generate a Orekit KeplerianOrbit
+        ss = KeplerianOrbit(
+            a,
+            ecc,
+            inc,
+            argp,
+            raan,
+            nu,
+            PositionAngle.TRUE,
+            frame,
+            epoch,
+            Constants.WGS84_EARTH_MU,
+        )
+
+        return cls(ss)
+
+    def classical(self):
+        """ Returns orbit classical elements """
+        coe = (
+            self.a,
+            self.ecc,
+            self.inc,
+            self.raan,
+            self.argp,
+            self.nu,
+        )
+
+        return coe
+
+    def rv(self):
+        """ Returns position and velocity vectors """
+        return self.r, self.v

--- a/orekit/src/utils.py
+++ b/orekit/src/utils.py
@@ -8,6 +8,8 @@ from orekit.pyhelpers import setup_orekit_curdir
 
 import orekit
 
+logger = logging.getLogger(__name__)
+
 OREKIT_SRC_DIR = os.path.dirname(os.path.abspath(__file__))
 OREKIT_DATA_DIR = os.path.join(OREKIT_SRC_DIR, "data")
 OREKIT_DATA_PATH = os.path.join(OREKIT_DATA_DIR, "orekit-data.zip")
@@ -25,9 +27,6 @@ def build_data_dir(dirname_path=OREKIT_DATA_DIR):
 def download_orekit_data(save_path=OREKIT_DATA_PATH, chunk_size=128):
     """ Downloads orekit ZIP data """
 
-    # Prepare the logger
-    log = logging.getLogger(__name__)
-
     # Official data download link
     url = "https://gitlab.orekit.org/orekit/orekit-data/-/archive/master/orekit-data-master.zip"
 
@@ -36,7 +35,7 @@ def download_orekit_data(save_path=OREKIT_DATA_PATH, chunk_size=128):
     with open(save_path, "wb") as fd:
         for chunk in r.iter_content(chunk_size=chunk_size):
             fd.write(chunk)
-    log.info("Data downloaded correctly.")
+    logger.info("Data downloaded correctly.")
 
 
 def setup_orekit_env(data_path=OREKIT_DATA_PATH):

--- a/orekit/src/utils.py
+++ b/orekit/src/utils.py
@@ -1,0 +1,57 @@
+""" Utilities for working with Orekit wrapper """
+
+import logging
+import os
+
+import requests
+from orekit.pyhelpers import setup_orekit_curdir
+
+import orekit
+
+OREKIT_SRC_DIR = os.path.dirname(os.path.abspath(__file__))
+OREKIT_DATA_DIR = os.path.join(OREKIT_SRC_DIR, "data")
+OREKIT_DATA_PATH = os.path.join(OREKIT_DATA_DIR, "orekit-data.zip")
+
+
+def build_data_dir(dirname_path=OREKIT_DATA_DIR):
+    """ Builds orekit data directory """
+
+    try:
+        os.mkdir(dirname_path)
+    except FileExistsError:
+        pass
+
+
+def download_orekit_data(save_path=OREKIT_DATA_PATH, chunk_size=128):
+    """ Downloads orekit ZIP data """
+
+    # Prepare the logger
+    log = logging.getLogger(__name__)
+
+    # Official data download link
+    url = "https://gitlab.orekit.org/orekit/orekit-data/-/archive/master/orekit-data-master.zip"
+
+    # Start downloading process and inform user when done
+    r = requests.get(url, stream=True)
+    with open(save_path, "wb") as fd:
+        for chunk in r.iter_content(chunk_size=chunk_size):
+            fd.write(chunk)
+    log.info("Data downloaded correctly.")
+
+
+def setup_orekit_env(data_path=OREKIT_DATA_PATH):
+    """ Sets up the orekit virtual machine and data directory """
+
+    # Create data directory if necessary
+    if not os.path.exists(OREKIT_DATA_DIR):
+        build_data_dir(OREKIT_DATA_DIR)
+
+    # Download data ZIP file if required
+    if not os.path.exists(OREKIT_DATA_PATH):
+        download_orekit_data(OREKIT_DATA_PATH)
+
+    # Setup the virtual machine and data location
+    vm = orekit.initVM()
+    setup_orekit_curdir(OREKIT_DATA_PATH)
+
+    return vm

--- a/orekit/tests/conftest.py
+++ b/orekit/tests/conftest.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+import pytest
+
+# Get orekit validation tests/ and find the src/ one
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+OREKIT_SRC_DIR = os.path.join(TESTS_DIR, os.pardir, "src")
+
+# Append src/ to path to access custom orekit modules
+sys.path.append(OREKIT_SRC_DIR)

--- a/orekit/tests/pytest.ini
+++ b/orekit/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --disable-warnings -vvv

--- a/orekit/tests/test_twobody_orbit.py
+++ b/orekit/tests/test_twobody_orbit.py
@@ -54,3 +54,22 @@ def test_orekit_orbit_from_classical():
     # Assert position and velocity vectors
     assert_quantity_allclose(ss_poliastro.r, ss_orekit.r)
     assert_quantity_allclose(ss_poliastro.v, ss_orekit.v)
+
+
+def test_orekit_orbit_propagation():
+
+    # Data from Vallado, example 2.4
+    r0 = [1131.340, -2282.343, 6672.423] * u.km
+    v0 = [-5.64305, 4.30333, 2.42879] * u.km / u.s
+    expected_r = [-4219.7527, 4363.0292, -3958.7666] * u.km
+    expected_v = [3.689866, -1.916735, -6.112511] * u.km / u.s
+
+    tof = 40 * u.min
+    ss_poliastro = Orbit.from_vectors(Earth, r0, v0).propagate(tof)
+    ss_orekit = OrekitOrbit.from_vectors(Earth, r0, v0).propagate(tof)
+
+    rr_poliastro, vv_poliastro = ss_poliastro.rv()
+    rr_orekit, vv_orekit = ss_orekit.rv()
+
+    assert_quantity_allclose(rr_poliastro, rr_orekit)
+    assert_quantity_allclose(vv_poliastro, vv_orekit)

--- a/orekit/tests/test_twobody_orbit.py
+++ b/orekit/tests/test_twobody_orbit.py
@@ -1,0 +1,56 @@
+""" Test cases for two-body orbit behaviors """
+
+# Import required orekit data in current directory
+import pytest
+from astropy import units as u
+import numpy as np
+from astropy.tests.helper import assert_quantity_allclose
+from numpy.testing import assert_allclose
+from orekit_orbit import OrekitOrbit
+from poliastro.bodies import Earth
+from poliastro.twobody import Orbit
+from utils import setup_orekit_env
+
+# Start orekit virtual machine and load data
+vm = setup_orekit_env()
+
+
+def test_orekit_orbit_from_rv():
+
+    # Initial RV elements
+    r = [-6045, -3490, 2500] * u.km
+    v = [-3.457, 6.618, 2.533] * u.km / u.s
+
+    # Generate orekit and poliastro orbits
+    ss_orekit = OrekitOrbit.from_vectors(Earth, r, v)
+    ss_poliastro = Orbit.from_vectors(Earth, r, v)
+
+    # Assert position and velocity vectors
+    assert_quantity_allclose(ss_poliastro.a, ss_orekit.a)
+    assert_quantity_allclose(ss_poliastro.ecc, ss_orekit.ecc)
+    assert_quantity_allclose(ss_poliastro.inc, ss_orekit.inc)
+    assert_quantity_allclose(ss_poliastro.raan, ss_orekit.raan)
+    assert_quantity_allclose(ss_poliastro.argp, ss_orekit.argp)
+    assert_quantity_allclose(ss_poliastro.nu, ss_orekit.nu)
+
+
+def test_orekit_orbit_from_classical():
+
+    # Initial COE elements
+    a = 1.523679 * u.AU
+    ecc = 0.093315 * u.one
+    inc = 1.85 * u.deg
+    raan = 49.562 * u.deg
+    argp = 286.537 * u.deg
+    nu = 23.33 * u.deg
+
+    # Generate COE element set
+    coe = [a, ecc, inc, raan, argp, nu]
+
+    # Generate orekit and poliastro orbits
+    ss_orekit = OrekitOrbit.from_classical(Earth, *coe)
+    ss_poliastro = Orbit.from_classical(Earth, *coe)
+
+    # Assert position and velocity vectors
+    assert_quantity_allclose(ss_poliastro.r, ss_orekit.r)
+    assert_quantity_allclose(ss_poliastro.v, ss_orekit.v)


### PR DESCRIPTION
This pull request is a first approach to poliastro's validation path. It makes use of the Orekit python wrapper and implements the following features:

* A class under the name `OrekitOrbit`, who's usage is similar to poliastro's `Orbit` class. Both of them try to model Keplerian orbits, which can be defined from vectors or classic orbital elements.

* A simple test regarding the conversion between RV and COE. 

:warning: Orekit does not provide functions like `rv2coe` or `coe2rv`, since conversion is done directly in each of the available constructors of the `KeplerianOrbit` class in the Orekit library :warning: 

Also notice the addition of the `orekit-data.zip` file, which holds necessary data for Orekit to properly work: ephemeris, time files... We might discuss if this data should be included within this repo or final user is required to download it from official channels.