### PR TITLE
Enable repository dispatch from poliastro

### DIFF
--- a/.github/workflows/ci_actions.yml
+++ b/.github/workflows/ci_actions.yml
@@ -8,6 +8,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  repository_dispatch:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This modification will enable [poliastro](https://github.com/poliastro/poliastro/) to trigger this repository CI actions.