### PR TITLE
Maneuvers validation againts Orekit

### DIFF
--- a/orekit/src/orekit_maneuvers.py
+++ b/orekit/src/orekit_maneuvers.py
@@ -1,0 +1,61 @@
+""" Simulate Orekit maneuvers as poliastro ones """
+
+import numpy as np
+from astropy import units as u
+
+from utils import vm  # noqa: F401 # isort: split
+from org.hipparchus.geometry.euclidean.threed import Vector3D
+from org.orekit.attitudes import LofOffset
+from org.orekit.forces.maneuvers import ImpulseManeuver
+from org.orekit.frames import LOFType
+from org.orekit.propagation.events import ApsideDetector
+from org.orekit.propagation.events.handlers import StopOnDecreasing
+
+
+class OrekitManeuver:
+    """ Class for modeling impulsive maneuvers """
+
+    def __init__(self, burns, attitude_provider):
+        """ Initializes the maneuver """
+
+        # Save the ImpulsiveManeuver instances and the attitude
+        self.burns = burns
+        self.attitude_provider = attitude_provider
+
+        # Allocate the final dV vectors
+        self._dvs = [dV.getDeltaVSat().toArray() * u.m / u.s for dV in self.burns]
+
+    @classmethod
+    def hohmann(cls, orekit_ss, rf_norm, ISP=float(300)):
+        """ Computes required impulses for a Hohmann transfer """
+
+        # Get required parameters and auxiliary ones
+        k = orekit_ss.attractor.k
+        r0_norm = orekit_ss.r_p
+        v0_norm = np.sqrt(2 * k / r0_norm - k / orekit_ss.a)
+        a_trans = (r0_norm + rf_norm) / 2
+
+        # Compute the magnitude of Hohmann's deltaV
+        dv_a = np.sqrt(2 * k / r0_norm - k / a_trans) - v0_norm
+        dv_b = np.sqrt(k / rf_norm) - np.sqrt(2 * k / rf_norm - k / a_trans)
+
+        # Local orbit frame: X-axis aligned with velocity, Z-axis towards momentum
+        attitude_provider = LofOffset(orekit_ss.frame, LOFType.TNW)
+
+        # Convert previous magnitudes into vectors within the TNW frame, which
+        # is aligned with local velocity vector
+        dVa_vec, dVb_vec = [
+            Vector3D(float(dV.to(u.m / u.s).value), float(0), float(0))
+            for dV in (dv_a, dv_b)
+        ]
+
+        # Define the events when that trigger the impulses
+        at_periapsis = ApsideDetector(orekit_ss._state)
+        at_apoapsis = ApsideDetector(orekit_ss._state).withHandler(StopOnDecreasing())
+
+        # Build the maneuvers
+        imp_A = ImpulseManeuver(at_periapsis, attitude_provider, dVa_vec, ISP)
+        imp_B = ImpulseManeuver(at_apoapsis, attitude_provider, dVb_vec, ISP)
+        burns = (imp_A, imp_B)
+
+        return cls(burns, attitude_provider)

--- a/orekit/src/orekit_orbit.py
+++ b/orekit/src/orekit_orbit.py
@@ -90,6 +90,16 @@ class OrekitOrbit:
         return self._state.getPerigeeArgument() * u.rad
 
     @property
+    def r_p(self):
+        """ Magnitude of the radius of periapsis """
+        return self.a * (1 - self.ecc)
+
+    @property
+    def r_a(self):
+        """ Magnitude of the radius of apoapsis """
+        return self.a * (1 + self.ecc)
+
+    @property
     def nu(self):
         """ True anomaly """
         return self._state.getTrueAnomaly() * u.rad

--- a/orekit/src/orekit_orbit.py
+++ b/orekit/src/orekit_orbit.py
@@ -196,3 +196,15 @@ class OrekitOrbit:
 
         # Return a new orbit from
         return OrekitOrbit.from_vectors(self.attractor, r, v, new_epoch, self.frame)
+
+    def apply_maneuver(self, man, tof):
+        """ Applies a maneuver to current orbit """
+
+        # Update internal propagator with the new attitude
+        self._propagator = KeplerianPropagator(self._state, man.attitude_provider)
+
+        # Add impulses to previous propagator
+        for burn in man.burns:
+            self._propagator.addEventDetector(burn)
+
+        return self.propagate(tof)

--- a/orekit/tests/test_maneuvers.py
+++ b/orekit/tests/test_maneuvers.py
@@ -1,0 +1,54 @@
+""" Validates poliastro's maneuvers against Orekit ones """
+
+import pytest
+from astropy import units as u
+from astropy.tests.helper import assert_quantity_allclose
+from orekit_maneuvers import OrekitManeuver
+from orekit_orbit import OrekitOrbit
+from poliastro.bodies import Earth
+from poliastro.maneuver import Maneuver
+from poliastro.twobody import Orbit
+
+# A collection of APIs to be validated against each other
+API_set = {"Orekit": [OrekitOrbit, OrekitManeuver], "poliastro": [Orbit, Maneuver]}
+
+
+@pytest.mark.parametrize("API", API_set)
+def test_3D_hohmann_maneuver(API):
+    # Initial orbit data
+    r = [7200, -1000, 0] * u.km
+    v = [0, 8, 0] * u.km / u.s
+
+    # Expected final state vector computed using GMAT-2020a
+    tof_expected = 19790.48929209821 * u.s
+    r_expected = [
+        -18447.18133044379e3,
+        -30659.53028128713e3,
+        0.002151253568205197e3,
+    ] * u.m
+    v_expected = (
+        [2.859891380100071e3, -1.720738616179917e3, -2.579688114910805e-04] * u.m / u.s
+    )
+
+    # Expected impulses as seen from the PQW local orbit frame
+    expected_dVa = [1.47424834733, 0, 0] * u.km / u.s
+    expected_dVb = [1.44567622075, 0, 0] * u.km / u.s
+
+    # Unpack API utilities
+    OrbitAPI, ManeuverAPI = API_set[API]
+
+    # Initial orbit, maneuver and final orbit
+    ss_0 = OrbitAPI.from_vectors(Earth, r, v)
+    man = ManeuverAPI.hohmann(ss_0, 35781.34857 * u.km)
+
+    # Orekit is triggered by internal events while poliastro requires
+    # propagation after maneuver has been applied
+    if API == "Orekit":
+        ss_f = ss_0.apply_maneuver(man, tof_expected)
+        assert_quantity_allclose(man._dvs[0], expected_dVa, rtol=1e-5)
+        assert_quantity_allclose(man._dvs[-1], expected_dVb, rtol=1e-5)
+    else:
+        ss_f = ss_0.apply_maneuver(man).propagate(1 * u.hour)
+
+    assert_quantity_allclose(ss_f.r, r_expected, atol=1 * u.km)
+    assert_quantity_allclose(ss_f.v, v_expected, atol=0.01 * u.km / u.s)

--- a/orekit/tests/test_raw_hohmann.py
+++ b/orekit/tests/test_raw_hohmann.py
@@ -1,0 +1,116 @@
+""" Test 3D Hohmann maneuvers from Orekit against poliastro ones """
+
+import astropy.units as u
+import numpy as np
+from astropy.tests.helper import assert_quantity_allclose
+from poliastro.bodies import Earth
+from poliastro.maneuver import Maneuver
+from poliastro.twobody import Orbit
+
+# Setup the virtual machine and data location
+import orekit 
+from orekit.pyhelpers import setup_orekit_curdir
+
+vm = orekit.initVM() 
+
+# Data orekit-data.zip must be located at same dir/ level that this script
+setup_orekit_curdir("src/data/orekit-data.zip") 
+
+
+# Import different utilities from Orekit API
+from org.hipparchus.geometry.euclidean.threed import Vector3D
+from org.orekit.attitudes import LofOffset
+from org.orekit.forces.maneuvers import ImpulseManeuver
+from org.orekit.frames import FramesFactory, LOFType
+from org.orekit.orbits import KeplerianOrbit
+from org.orekit.propagation.analytical import KeplerianPropagator
+from org.orekit.propagation.events import ApsideDetector
+from org.orekit.propagation.events.handlers import StopOnDecreasing
+from org.orekit.time import AbsoluteDate
+from org.orekit.utils import Constants as C
+from org.orekit.utils import PVCoordinates
+
+
+def test_poliastro_3Dhohmann():
+
+    # Initial orbit state vectors, final radius and time of flight
+    rx_0, ry_0, rz_0 = [float(ri_0) for ri_0 in [7200e3, -1000e3, 0]]
+    vx_0, vy_0, vz_0 = [float(vi_0) for vi_0 in [0, 8e3, 0]]
+    rf_norm = float(35781.34857e3)
+    tof = float(19790.48929209821)
+
+    # Build the initial Orekit orbit
+    k = C.IAU_2015_NOMINAL_EARTH_GM
+    r0_vec = Vector3D(rx_0, ry_0, rz_0)
+    v0_vec = Vector3D(vx_0, vy_0, vz_0)
+    rv_0 = PVCoordinates(r0_vec, v0_vec)
+    epoch_00 = AbsoluteDate.J2000_EPOCH
+    gcrf_frame = FramesFactory.getGCRF()
+    ss0_orekit = KeplerianOrbit(rv_0, gcrf_frame, epoch_00, k)
+
+    # Final desired orbit radius and auxiliary variables
+    r0_norm = ss0_orekit.getA() * (1 - ss0_orekit.getE())
+    v0_norm = np.sqrt(2 * k / r0_norm - k / ss0_orekit.getA())
+    a_trans = (r0_norm + rf_norm) / 2
+
+    # Compute the magnitude of Hohmann's deltaV
+    dv_a = np.sqrt(2 * k / r0_norm - k / a_trans) - v0_norm
+    dv_b = np.sqrt(k / rf_norm) - np.sqrt(2 * k / rf_norm - k / a_trans)
+    dVa_vec, dVb_vec = [Vector3D(float(dV), float(0), float(0)) for dV in (dv_a, dv_b)]
+
+    # Local orbit frame: X-axis aligned with velocity, Z-axis towards momentum
+    attitude_provider = LofOffset(gcrf_frame, LOFType.TNW)
+
+    # Setup the triggers for the impulses execution
+    at_periapsis = ApsideDetector(ss0_orekit)
+    at_apoapsis = ApsideDetector(ss0_orekit).withHandler(StopOnDecreasing())
+
+    # Build the impulsive maneuvers
+    ISP = float(300)
+    imp_A = ImpulseManeuver(at_periapsis, attitude_provider, dVa_vec, ISP)
+    imp_B = ImpulseManeuver(at_apoapsis, attitude_provider, dVb_vec, ISP)
+
+    # Generate the propagator and add the maneuvers
+    propagator = KeplerianPropagator(ss0_orekit, attitude_provider)
+    propagator.addEventDetector(imp_A)
+    propagator.addEventDetector(imp_B)
+
+    # Expected time of flight
+    epoch_ff = epoch_00.shiftedBy(tof)
+
+    # Propagate the Orekit orbit
+    rv_f = propagator.propagate(epoch_ff).getPVCoordinates(gcrf_frame)
+    rf_orekit, vf_orekit = (
+        (list(rv_f.getPosition().toArray()) * u.m),
+        (list(rv_f.getVelocity().toArray()) * u.m / u.s),
+    )
+
+    # Build the orbit with poliastro
+    ss0_poliastro = Orbit.from_vectors(
+        Earth, r0_vec.toArray() * u.m, v0_vec.toArray() * u.m / u.s
+    )
+    man_poliastro = Maneuver.hohmann(ss0_poliastro, rf_norm * u.m)
+    rf_poliastro, vf_poliastro = (
+        ss0_poliastro.apply_maneuver(man_poliastro).propagate(1 * u.h).rv()
+    )
+
+    # Check if final vectors match expected ones predicted by GMAT-NASA 2020a
+    rf_expected = [
+        -18447.18133044379e3,
+        -30659.53028128713e3,
+        0.002151253568205197e3,
+    ] * u.m
+    vf_expected = (
+        [2.859891380100071e3, -1.720738616179917e3, -2.579688114910805e-04] * u.m / u.s
+    )
+
+    # Test Orekit against GMAT
+    assert_quantity_allclose(rf_orekit, rf_expected, atol=50 * u.m, rtol=1e-4)
+    assert_quantity_allclose(vf_orekit, vf_expected, atol=0.0035 * u.m / u.s, rtol=1e-5)
+
+    # test poliastro against Orekit
+    assert_quantity_allclose(rf_poliastro, rf_orekit, rtol=1e-6)
+    assert_quantity_allclose(vf_poliastro, vf_orekit, rtol=1e-6)
+
+    # Assert total time of flight = time of maneuver + 1 hour of propagation
+    assert_quantity_allclose(man_poliastro.get_total_time() + 1 * u.h, tof * u.s)


### PR DESCRIPTION
This PR solves for gh-10. By adding a `apply_maneuver` method to the actual `OrekitOrbit` class (same API as poliastro), it is possible to apply impulsive maneuvers to any instance of the object. However, some problems were found when implementing this:

* It seems that a long time of flight, the `KeplerianPropagator` hangs and raises an error. This has nothing to do with the actual implementation but a really weird behavior discovered while working on the issue.
* The impulses are defined in the `TNW` basis, which stands for "tangential" as this frame is aligned with local velocity. Therefore, impulses are always in the direction of the spacecraft velocity.
*  Expected values for the test were computed using GMAT. This is due to the fact that Orekit based maneuvers did not match poliastro's results and thus, an additional source of results was needed. My idea is to keep these expected values till we find which is the error introduced in the Orekit maneuvers implementation.

I guess it can be something related with frames, since vectors were introduced in the `TNW`. Hopefully, studying those will be helpful not only for this issue but also when validating planetary reference frames.  