### PR TITLE
Fix order of magnitudes

### DIFF
--- a/orekit/tests/validate_twobody/validate_elements.py
+++ b/orekit/tests/validate_twobody/validate_elements.py
@@ -22,8 +22,8 @@ setup_orekit_curdir("orekit-data.zip")
 
 def validate_rv2coe():
     # Orbit initial state vectors
-    rx_0, ry_0, rz_0 = -6045.0, -3490.0, 2500.0
-    vx_0, vy_0, vz_0 = -3.457, 6.618, 2.533
+    rx_0, ry_0, rz_0 = -6045.0e3, -3490.0e3, 2500.0e3
+    vx_0, vy_0, vz_0 = -3.457e3, 6.618e3, 2.533e3
 
     # Build the initial Orekit orbit
     k = C.IAU_2015_NOMINAL_EARTH_GM
@@ -65,7 +65,7 @@ def validate_rv2coe():
 def validate_coe2rv():
 
     # Initial COE of the orbit
-    a, ecc, inc, raan, argp, nu = 87800e3, 0.1712, 2.6738, 4.4558, 0.3612, 0.4965
+    a, ecc, inc, raan, argp, nu = 8788e3, 0.1712, 2.6738, 4.4558, 0.3502, 0.4965
 
     # Build Orekit orbit
     k = C.IAU_2015_NOMINAL_EARTH_GM


### PR DESCRIPTION
I noticed the order of magnitude of the initial position vector in `validate_elements::validate_rv2coe` was given in `u.km` but assumed to be in `u.m` during the whole workflow. Just a quick fix :sweat_smile: 