### PR TITLE
Validate Hohmann 3D maneuver

### DIFF
--- a/gmat/tests/gmat_validate_hohmann3D.script
+++ b/gmat/tests/gmat_validate_hohmann3D.script
@@ -1,0 +1,141 @@
+%----------------------------------------
+%-- GMAT validate Hohmann 3D maneuvers --
+%----------------------------------------
+
+% ABOUT
+% -----
+%
+% The following script tries to validate
+% poliastro's Hohmann maneuvers against 
+% GMAT2020a version.
+
+%----------------------------------------
+%---------- Spacecraft
+%----------------------------------------
+
+% Build spacecraft's orbit from vectors
+Create Spacecraft ss_0;
+GMAT ss_0.DateFormat = TAIGregorian;
+GMAT ss_0.CoordinateSystem = EarthICRF;
+GMAT ss_0.DisplayStateType = Cartesian;
+GMAT ss_0.X = 7200; 
+GMAT ss_0.Y = -1000;
+GMAT ss_0.Z = 0;
+GMAT ss_0.VX = 0;
+GMAT ss_0.VY =  8.00;
+GMAT ss_0.VZ = 3.25;
+
+%----------------------------------------
+%---------- ForceModel
+%----------------------------------------
+
+% Build a two-body two-point force model
+Create ForceModel PointMass;
+GMAT PointMass.CentralBody = Earth;
+GMAT PointMass.PrimaryBodies = {Earth};
+GMAT PointMass.Drag = None;
+GMAT PointMass.SRP = Off;
+GMAT PointMass.RelativisticCorrection = Off;
+GMAT PointMass.ErrorControl = RSSStep;
+GMAT PointMass.GravityField.Earth.Degree = 0;
+GMAT PointMass.GravityField.Earth.Order = 0;
+GMAT PointMass.GravityField.Earth.StmLimit = 100;
+
+
+%----------------------------------------
+%---------- Propagators
+%----------------------------------------
+
+% Create propgator with point mass only
+Create Propagator EarthPointMass;
+GMAT EarthPointMass.FM = PointMass;
+GMAT EarthPointMass.Type = PrinceDormand78;
+GMAT EarthPointMass.InitialStepSize = 0.5;
+GMAT EarthPointMass.Accuracy = 1e-12;
+GMAT EarthPointMass.MinStep = 0;
+GMAT EarthPointMass.MaxStep = 86400;
+GMAT EarthPointMass.MaxStepAttempts = 500;
+GMAT EarthPointMass.StopIfAccuracyIsViolated = false;
+
+%----------------------------------------
+%---------- Burns
+%----------------------------------------
+
+% Instantiate the first impulse
+Create ImpulsiveBurn dV_a;
+GMAT dV_a.CoordinateSystem = Local;
+GMAT dV_a.Origin = Earth;
+GMAT dV_a.Axes = VNB;
+GMAT dV_a.Element1 = 0;
+GMAT dV_a.Element2 = 0;
+GMAT dV_a.Element3 = 0;
+GMAT dV_a.DecrementMass = false;
+GMAT dV_a.Isp = 300;
+
+% Instantiate the second impulse
+Create ImpulsiveBurn dV_b;
+GMAT dV_b.CoordinateSystem = Local;
+GMAT dV_b.Origin = Earth;
+GMAT dV_b.Axes = VNB;
+GMAT dV_b.Element1 = 0;
+GMAT dV_b.Element2 = 0;
+GMAT dV_b.Element3 = 0;
+GMAT dV_b.DecrementMass = false;
+GMAT dV_b.Isp = 300;
+
+%----------------------------------------
+%---------- Solvers
+%----------------------------------------
+
+% Default GMAT solver
+Create DifferentialCorrector DC;
+GMAT DC.ShowProgress = true;
+GMAT DC.ReportStyle = Normal;
+GMAT DC.ReportFile = 'DifferentialCorrectorDC.data';
+GMAT DC.MaximumIterations = 25;
+GMAT DC.DerivativeMethod = ForwardDifference;
+GMAT DC.Algorithm = NewtonRaphson;
+
+%----------------------------------------
+%---------- Plots/Reports
+%----------------------------------------
+
+Create OrbitView GLPlot;
+GMAT GLPlot.Add = {ss_0, Earth};
+GMAT GLPlot.CoordinateSystem = EarthICRF;
+
+Create ReportFile report;
+GMAT report.SolverIterations = Current;
+GMAT report.Filename = 'ReportData.txt';
+GMAT report.Precision = 7;
+GMAT report.Add = {ss_0.UTCGregorian, ss_0.ElapsedSecs, ss_0.X, ss_0.Y, ss_0.Z, ss_0.VX, ss_0.VY, ss_0.VZ};
+GMAT report.WriteHeaders = true;
+GMAT report.LeftJustify = Off;
+GMAT report.ZeroFill = On;
+GMAT report.FixedWidth = true;
+GMAT report.Delimiter = ' ';
+GMAT report.ColumnWidth = 10;
+GMAT report.WriteReport = true;
+
+
+%----------------------------------------
+%---------- Mission Sequence
+%----------------------------------------
+BeginMissionSequence;
+
+% Propagate to perigee to ensure maneuver is properly applied
+Propagate 'Propagate to perigee' EarthPointMass(ss_0) {ss_0.Periapsis};
+
+% Burn in the velocity direction to reach an alternate Apoapsis point
+Target 'Apply Hohmann maneuver' DC {SolveMode = Solve, ExitMode = DiscardAndContinue, ShowProgressWindow = false};
+   Vary 'Find dV_a' DC(dV_a.Element1 = 0.5, {Perturbation = 0.0001, Lower = 0, Upper = 3.14159, MaxStep = 0.2, AdditiveScaleFactor = 0.0, MultiplicativeScaleFactor = 1.0});
+   Maneuver 'Apply dV_a burn' dV_a(ss_0);
+   Propagate 'Propagate to apogee' EarthPointMass(ss_0) {ss_0.Apoapsis};
+   Achieve 'Achieve rf_norm' DC(ss_0.Earth.RMAG = 35781.34857, {Tolerance = 0.01});
+   Vary 'Find dV_b' DC(dV_b.Element1 = 0.5, {Perturbation = 0.0001, Lower = 0, Upper = 3.14159, MaxStep = 0.2, AdditiveScaleFactor = 0.0, MultiplicativeScaleFactor = 1.0});
+   Maneuver 'Apply dV_b' dV_b(ss_0);
+   Achieve 'Achieve circular orbit' DC(ss_0.ECC = 0, {Tolerance = 0.01});
+EndTarget;
+
+% Propagate to leave apoapsis behind so GMAT can apply the last burn
+Propagate 'Propagate 1 hour' EarthPointMass(ss_0) {ss_0.ElapsedSecs = 3600};

--- a/orekit/tests/validate_maneuvers.py
+++ b/orekit/tests/validate_maneuvers.py
@@ -1,0 +1,108 @@
+""" Modeling Hohmann impulsive transfer with Orekit Python wrapper """
+
+import numpy as np
+from astropy import units as u
+from astropy.tests.helper import assert_quantity_allclose
+from org.hipparchus.geometry.euclidean.threed import Vector3D
+from org.orekit.attitudes import LofOffset
+from org.orekit.forces.maneuvers import ImpulseManeuver
+from org.orekit.frames import FramesFactory, LOFType
+from org.orekit.orbits import KeplerianOrbit
+from org.orekit.propagation.analytical import KeplerianPropagator
+from org.orekit.propagation.events import ApsideDetector
+from org.orekit.propagation.events.handlers import StopOnDecreasing
+from org.orekit.time import AbsoluteDate
+from org.orekit.utils import Constants as C
+from org.orekit.utils import PVCoordinates
+from poliastro.bodies import Earth
+from poliastro.maneuver import Maneuver
+from poliastro.twobody import Orbit
+
+import orekit
+from orekit.pyhelpers import setup_orekit_curdir
+
+# Setup orekit virtual machine and associated data
+VM = orekit.initVM()
+setup_orekit_curdir("orekit-data.zip")
+
+
+def validate_3D_hohmann():
+
+    # Initial orbit state vectors, final radius and time of flight
+    # This orbit has an inclination of 22.30 [deg] so the maneuver will not be
+    # applied on an equatorial orbit. See associated GMAT script:
+    # gmat_validate_hohmann3D.script
+    rx_0, ry_0, rz_0 = 7200e3, -1000.0e3, 0.0
+    vx_0, vy_0, vz_0 = 0.0, 8.0e3, 3.25e3
+    rf_norm = 35781.35e3
+    tof = 19800.00
+
+    # Build the initial Orekit orbit
+    k = C.IAU_2015_NOMINAL_EARTH_GM
+    r0_vec = Vector3D(rx_0, ry_0, rz_0)
+    v0_vec = Vector3D(vx_0, vy_0, vz_0)
+    rv_0 = PVCoordinates(r0_vec, v0_vec)
+    epoch_00 = AbsoluteDate.J2000_EPOCH
+    gcrf_frame = FramesFactory.getGCRF()
+    ss_0 = KeplerianOrbit(rv_0, gcrf_frame, epoch_00, k)
+
+    # Final desired orbit radius and auxiliary variables
+    a_0, ecc_0 = ss_0.getA(), ss_0.getE()
+    rp_norm = a_0 * (1 - ecc_0)
+    vp_norm = np.sqrt(2 * k / rp_norm - k / a_0)
+    a_trans = (rp_norm + rf_norm) / 2
+
+    # Compute the magnitude of Hohmann's deltaV
+    dv_a = np.sqrt(2 * k / rp_norm - k / a_trans) - vp_norm
+    dv_b = np.sqrt(k / rf_norm) - np.sqrt(2 * k / rf_norm - k / a_trans)
+
+    # Convert previous magnitudes into vectors within the TNW frame, which
+    # is aligned with local velocity vector
+    dVa_vec, dVb_vec = [Vector3D(float(dV), float(0), float(0)) for dV in (dv_a, dv_b)]
+
+    # Local orbit frame: X-axis aligned with velocity, Z-axis towards momentum
+    attitude_provider = LofOffset(gcrf_frame, LOFType.TNW)
+
+    # Setup impulse triggers; default apside detector stops on increasing g
+    # function (aka at perigee)
+    at_apoapsis = ApsideDetector(ss_0).withHandler(StopOnDecreasing())
+    at_periapsis = ApsideDetector(ss_0)
+
+    # Build the impulsive maneuvers; ISP is only related to fuel mass cost
+    ISP = float(300)
+    imp_A = ImpulseManeuver(at_periapsis, attitude_provider, dVa_vec, ISP)
+    imp_B = ImpulseManeuver(at_apoapsis, attitude_provider, dVb_vec, ISP)
+
+    # Generate the propagator and add the maneuvers
+    propagator = KeplerianPropagator(ss_0, attitude_provider)
+    propagator.addEventDetector(imp_A)
+    propagator.addEventDetector(imp_B)
+
+    # Apply the maneuver by propagating the orbit
+    epoch_ff = epoch_00.shiftedBy(tof)
+    rv_f = propagator.propagate(epoch_ff).getPVCoordinates(gcrf_frame)
+
+    # Retrieve orekit final state vectors
+    r_orekit, v_orekit = (
+        rv_f.getPosition().toArray() * u.m,
+        rv_f.getVelocity().toArray() * u.m / u.s,
+    )
+
+    # Build initial poliastro orbit and apply the maneuver
+    r0_vec = [rx_0, ry_0, rz_0] * u.m
+    v0_vec = [vx_0, vy_0, vz_0] * u.m / u.s
+    ss0_poliastro = Orbit.from_vectors(Earth, r0_vec, v0_vec)
+    man_poliastro = Maneuver.hohmann(ss0_poliastro, rf_norm * u.m)
+
+    # Retrieve propagation time after maneuver has been applied
+    tof_prop = tof - man_poliastro.get_total_time().to(u.s).value
+    ssf_poliastro = ss0_poliastro.apply_maneuver(man_poliastro).propagate(
+        tof_prop * u.s
+    )
+
+    # Retrieve poliastro final state vectors
+    r_poliastro, v_poliastro = ssf_poliastro.rv()
+
+    # Assert final state vectors
+    assert_quantity_allclose(r_poliastro, r_orekit, rtol=1e-6)
+    assert_quantity_allclose(v_poliastro, v_orekit, rtol=1e-6)


### PR DESCRIPTION
This pull request will validate poliastro's 3D Hohmann maneuvers. It includes an Orekit-based validation test but also a GMAT2020a script.

The initial orbit is a non-equatorial one, as it has around 23deg inclination. Furthermore, it does not start at perigee, so poliastro's internal propagation when applying Hohmann is also checked in here.