### PR TITLE
Validate SatelliteVisibilityEvent

### DIFF
--- a/orekit/tests/validate_events.py
+++ b/orekit/tests/validate_events.py
@@ -150,7 +150,7 @@ DICT_OF_EVENTS = {
     "satellite-visibility": [
         ElevationDetector(topo_frame).withHandler(StopOnEvent()),
         SatelliteVisibilityEvent(
-            ss0_poliastro, 46 * u.deg, 45 * u.deg, 5.0 * u.m, terminal=True
+            ss0_poliastro, 47 * u.deg, 45 * u.deg, 5.0 * u.m, terminal=True
         ),
     ],
 }


### PR DESCRIPTION
The currently added example of (lat, lon) = (46, 45) gives an error of `5579.119444` seconds. There are two more cases: (47, 45) and (45, 46) for (lat, on) values where I get an error. For all other pairs, I do not get an error.