### PR TITLE
Drop Python 3.7

### DIFF
--- a/.github/workflows/ci_actions.yml
+++ b/.github/workflows/ci_actions.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.9]
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
poliastro dropped Python 3.7 in https://github.com/poliastro/poliastro/pull/1434.